### PR TITLE
Append html wrapper method

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Please :star: if you like it.
 ```rb
 require 'prawn-html'
 pdf = Prawn::Document.new(page_size: 'A4')
-PrawnHtml::HtmlHandler.new(pdf).process('<h1 style="text-align: center">Just a test</h1>')
+PrawnHtml.append_html(pdf, '<h1 style="text-align: center">Just a test</h1>')
 pdf.render_file('test.pdf')
 ```
 

--- a/examples/samples.rb
+++ b/examples/samples.rb
@@ -10,7 +10,7 @@ require 'pry'
 Dir[File.expand_path('*.html', __dir__)].sort.each do |file|
   html = File.read(file)
   pdf = Prawn::Document.new(page_size: 'A4', page_layout: :portrait)
-  PrawnHtml::HtmlHandler.new(pdf).process(html)
+  PrawnHtml.append_html(pdf, html)
   out = file.gsub(/\.html\Z/, '.pdf')
   pdf.render_file(out)
 end

--- a/lib/prawn-html.rb
+++ b/lib/prawn-html.rb
@@ -13,5 +13,12 @@ require 'prawn_html/document_renderer'
 require 'prawn_html/html_handler'
 
 module PrawnHtml
-  PX = 0.66 # conversion costant for pixel sixes
+  PX = 0.66 # conversion constant for pixel sixes
+
+  def append_html(pdf, html)
+    handler = PrawnHtml::HtmlHandler.new(pdf)
+    handler.process(html)
+  end
+
+  module_function :append_html
 end

--- a/spec/features/samples_spec.rb
+++ b/spec/features/samples_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Samples' do
     it "renders the expected output for #{File.basename(file)}", :aggregate_failures do
       html = File.read(file)
       pdf = Prawn::Document.new(page_size: 'A4', page_layout: :portrait)
-      PrawnHtml::HtmlHandler.new(pdf).process(html)
+      PrawnHtml.append_html(pdf, html)
       expected_pdf = File.read(file.gsub(/\.html\Z/, '.pdf'))
       expect(Zlib.crc32(pdf.render)).to eq Zlib.crc32(expected_pdf)
     end

--- a/spec/support/test_utils.rb
+++ b/spec/support/test_utils.rb
@@ -32,7 +32,7 @@ module TestUtils
   def styled_text_document(html)
     prawn_document.tap do |pdf|
       yield(pdf) if block_given?
-      ::PrawnHtml::HtmlHandler.new(pdf).process(html)
+      PrawnHtml.append_html(pdf, html)
     end
   end
 end

--- a/spec/units/prawn_html_spec.rb
+++ b/spec/units/prawn_html_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe PrawnHtml do
+  describe '.append_html' do
+    subject(:append_html) { described_class.append_html(pdf, html) }
+
+    let(:pdf) { instance_double(Prawn::Document) }
+    let(:html) { '<div>some html</div>' }
+    let(:html_handler) { instance_double(PrawnHtml::HtmlHandler, process: true) }
+
+    before do
+      allow(PrawnHtml::HtmlHandler).to receive(:new).and_return(html_handler)
+    end
+
+    it 'creates an instance of PrawnHtml::HtmlHandler and call process', :aggregate_failures do
+      append_html
+      expect(PrawnHtml::HtmlHandler).to have_received(:new).with(pdf)
+      expect(html_handler).to have_received(:process).with(html)
+    end
+  end
+end


### PR DESCRIPTION
New wrapper method to allow a simplified syntax:
```rb
PrawnHtml.append_html(pdf, html)
```