### PR TITLE
Handle tag extra_styles

### DIFF
--- a/lib/prawn_html/tag.rb
+++ b/lib/prawn_html/tag.rb
@@ -45,6 +45,7 @@ module PrawnHtml
       attrs.merge_text_styles!(tag_styles, options: options) if respond_to?(:tag_styles)
       attrs.merge_text_styles!(element_styles, options: options) if element_styles
       attrs.merge_text_styles!(attrs.style, options: options)
+      attrs.merge_text_styles!(extra_styles, options: options) if respond_to?(:extra_styles)
     end
 
     # Styles to apply on tag closing

--- a/lib/prawn_html/tags/a.rb
+++ b/lib/prawn_html/tags/a.rb
@@ -5,12 +5,13 @@ module PrawnHtml
     class A < Tag
       ELEMENTS = [:a].freeze
 
-      def tag_styles
-        return unless attrs.href
+      def extra_styles
+        attrs.href ? "href: #{attrs.href}" : nil
+      end
 
+      def tag_styles
         <<~STYLES
           color: #00E;
-          href: #{attrs.href};
           text-decoration: underline;
         STYLES
       end

--- a/spec/units/prawn_html/tag_spec.rb
+++ b/spec/units/prawn_html/tag_spec.rb
@@ -41,6 +41,49 @@ RSpec.describe PrawnHtml::Tag do
     end
   end
 
+  describe '#process_styles' do
+    subject(:process_styles) { tag.process_styles(element_styles: element_styles) }
+
+    let(:element_styles) { nil }
+
+    before do
+      allow(tag.attrs).to receive(:merge_text_styles!)
+    end
+
+    it 'merges the inline styles' do
+      process_styles
+      expect(tag.attrs).to have_received(:merge_text_styles!).with('color: #0088ff', options: {})
+    end
+
+    context 'with some additional styles' do
+      let(:some_tag_class) do
+        Class.new(described_class) do
+          def extra_styles
+            'color: green; text-decoration: underline'
+          end
+
+          def tag_styles
+            'color: yellow; font-style: italic'
+          end
+        end
+      end
+
+      let(:element_styles) { 'color: red; font-weight: bold' }
+      let(:tag) { some_tag_class.new(:some_tag, attributes: attributes) }
+
+      it 'merges the tag styles', :aggregate_failures do
+        process_styles
+
+        expected_styles = 'color: yellow; font-style: italic'
+        expect(tag.attrs).to have_received(:merge_text_styles!).with(expected_styles, options: {}).ordered
+        expect(tag.attrs).to have_received(:merge_text_styles!).with(element_styles, options: {}).ordered
+        expect(tag.attrs).to have_received(:merge_text_styles!).with('color: #0088ff', options: {}).ordered
+        expected_styles = 'color: green; text-decoration: underline'
+        expect(tag.attrs).to have_received(:merge_text_styles!).with(expected_styles, options: {}).ordered
+      end
+    end
+  end
+
   describe '#styles' do
     subject(:styles) { tag.styles }
 

--- a/spec/units/prawn_html/tags/a_spec.rb
+++ b/spec/units/prawn_html/tags/a_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PrawnHtml::Tags::A do
     end
 
     it "styles doesn't include the link property" do
-      expect(a.styles).to eq(color: 'ffbb11')
+      expect(a.styles).to eq(color: 'ffbb11', styles: [:underline])
     end
   end
 


### PR DESCRIPTION
Extra styles are additional attributes per tag that need to be merged
in the styles. For example: href for A tag.