### PR TITLE
Introduce PrawnHtml::Instance class to preserve the context

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ pdf.render_file('test.pdf')
 
 To check some examples with the PDF output see [examples](examples/) folder.
 
+Alternative form using _PrawnHtml::Instance_ to preserve the context:
+
+```rb
+require 'prawn-html'
+pdf = Prawn::Document.new(page_size: 'A4')
+phtml = PrawnHtml::Instance.new(pdf)
+css = <<~CSS
+  h1 { color: green }
+  i { color: red }
+CSS
+phtml.append(css: css)
+phtml.append(html: '<h1>Some <i>HTML</i> before</h1>')
+pdf.text 'Some Prawn text'
+phtml.append(html: '<h1>Some <i>HTML</i> after</h1>')
+pdf.render_file('test.pdf')
+```
+
 ## Supported tags & attributes
 
 HTML tags (using MDN definitions):

--- a/examples/instance.pdf
+++ b/examples/instance.pdf
@@ -17,7 +17,7 @@ endobj
 >>
 endobj
 4 0 obj
-<< /Length 430
+<< /Length 904
 >>
 stream
 q
@@ -29,7 +29,29 @@ q
 BT
 36.0 777.3198 Td
 /F2.0 18.9 Tf
-[<536f6d652048544d4c20626566> 20 <6f7265>] TJ
+[<536f6d6520>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+1.0 0.0 0.0 scn
+1.0 0.0 0.0 SCN
+
+BT
+92.7189 777.3198 Td
+/F3.0 18.9 Tf
+[<48544d4c>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.0 0.50196 0.0 scn
+0.0 0.50196 0.0 SCN
+
+BT
+145.2042 777.3198 Td
+/F2.0 18.9 Tf
+[<20626566> 20 <6f7265>] TJ
 ET
 
 0.0 0.0 0.0 SCN
@@ -47,7 +69,29 @@ ET
 BT
 36.0 722.5548 Td
 /F2.0 18.9 Tf
-[<536f6d652048544d4c206166746572>] TJ
+[<536f6d6520>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+1.0 0.0 0.0 scn
+1.0 0.0 0.0 SCN
+
+BT
+92.7189 722.5548 Td
+/F3.0 18.9 Tf
+[<48544d4c>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.0 0.50196 0.0 scn
+0.0 0.50196 0.0 SCN
+
+BT
+145.2042 722.5548 Td
+/F2.0 18.9 Tf
+[<206166746572>] TJ
 ET
 
 0.0 0.0 0.0 SCN
@@ -67,7 +111,8 @@ endobj
 /Contents 4 0 R
 /Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
 /Font << /F2.0 6 0 R
-/F1.0 7 0 R
+/F3.0 7 0 R
+/F1.0 8 0 R
 >>
 >>
 >>
@@ -82,25 +127,33 @@ endobj
 7 0 obj
 << /Type /Font
 /Subtype /Type1
+/BaseFont /Helvetica-BoldOblique
+/Encoding /WinAnsiEncoding
+>>
+endobj
+8 0 obj
+<< /Type /Font
+/Subtype /Type1
 /BaseFont /Helvetica
 /Encoding /WinAnsiEncoding
 >>
 endobj
 xref
-0 8
+0 9
 0000000000 65535 f 
 0000000015 00000 n 
 0000000109 00000 n 
 0000000158 00000 n 
 0000000215 00000 n 
-0000000696 00000 n 
-0000001004 00000 n 
-0000001106 00000 n 
+0000001170 00000 n 
+0000001490 00000 n 
+0000001592 00000 n 
+0000001701 00000 n 
 trailer
-<< /Size 8
+<< /Size 9
 /Root 2 0 R
 /Info 1 0 R
 >>
 startxref
-1203
+1798
 %%EOF

--- a/examples/instance.pdf
+++ b/examples/instance.pdf
@@ -1,0 +1,106 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 430
+>>
+stream
+q
+/DeviceRGB cs
+0.0 0.50196 0.0 scn
+/DeviceRGB CS
+0.0 0.50196 0.0 SCN
+
+BT
+36.0 777.3198 Td
+/F2.0 18.9 Tf
+[<536f6d652048544d4c20626566> 20 <6f7265>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+
+BT
+36.0 746.901 Td
+/F1.0 12 Tf
+[<536f6d65205072> 10 <61> 20 <776e207465> 30 <7874>] TJ
+ET
+
+0.0 0.50196 0.0 scn
+0.0 0.50196 0.0 SCN
+
+BT
+36.0 722.5548 Td
+/F2.0 18.9 Tf
+[<536f6d652048544d4c206166746572>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 6 0 R
+/F1.0 7 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica-Bold
+/Encoding /WinAnsiEncoding
+>>
+endobj
+7 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000696 00000 n 
+0000001004 00000 n 
+0000001106 00000 n 
+trailer
+<< /Size 8
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+1203
+%%EOF

--- a/lib/prawn-html.rb
+++ b/lib/prawn-html.rb
@@ -156,10 +156,7 @@ module PrawnHtml
   }.freeze
 
   def append_html(pdf, html)
-    pdf_wrapper = PdfWrapper.new(pdf)
-    renderer = DocumentRenderer.new(pdf_wrapper)
-    html_parser = PrawnHtml::HtmlParser.new(renderer)
-    html_parser.process(html)
+    PrawnHtml::Instance.new(pdf).append(html: html)
   end
 
   module_function :append_html
@@ -179,3 +176,4 @@ require 'prawn_html/context'
 require 'prawn_html/pdf_wrapper'
 require 'prawn_html/document_renderer'
 require 'prawn_html/html_parser'
+require 'prawn_html/instance'

--- a/lib/prawn_html/html_parser.rb
+++ b/lib/prawn_html/html_parser.rb
@@ -30,6 +30,13 @@ module PrawnHtml
       renderer.flush
     end
 
+    # Parses CSS styles
+    #
+    # @param text_styles [String] The CSS styles to evaluate
+    def parse_styles(text_styles)
+      @raw_styles = text_styles.scan(REGEXP_STYLES).to_h
+    end
+
     private
 
     attr_reader :document, :ignore, :processing, :renderer, :styles
@@ -62,7 +69,7 @@ module PrawnHtml
     end
 
     def process_styles(text_styles = nil)
-      @raw_styles = text_styles.scan(REGEXP_STYLES).to_h if text_styles
+      parse_styles(text_styles) if text_styles
       @raw_styles.each do |selector, rule|
         document.css(selector).each do |node|
           styles[node] = rule

--- a/lib/prawn_html/html_parser.rb
+++ b/lib/prawn_html/html_parser.rb
@@ -15,15 +15,17 @@ module PrawnHtml
       @ignore = false
       @ignore_content_tags = ignore_content_tags
       @renderer = renderer
-      @styles = {}
+      @raw_styles = {}
     end
 
     # Processes HTML and renders it
     #
     # @param html [String] The HTML content to process
     def process(html)
+      @styles = {}
       @processing = !html.include?('<body')
       @document = Oga.parse_html(html)
+      process_styles # apply previously loaded styles
       traverse_nodes(document.children)
       renderer.flush
     end
@@ -59,9 +61,9 @@ module PrawnHtml
       end
     end
 
-    def process_styles(text_styles)
-      hash_styles = text_styles.scan(REGEXP_STYLES).to_h
-      hash_styles.each do |selector, rule|
+    def process_styles(text_styles = nil)
+      @raw_styles = text_styles.scan(REGEXP_STYLES).to_h if text_styles
+      @raw_styles.each do |selector, rule|
         document.css(selector).each do |node|
           styles[node] = rule
         end

--- a/lib/prawn_html/instance.rb
+++ b/lib/prawn_html/instance.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module PrawnHtml
+  class Instance
+    attr_reader :html_parser, :pdf_wrapper, :renderer
+
+    def initialize(pdf)
+      @pdf_wrapper = PrawnHtml::PdfWrapper.new(pdf)
+      @renderer = PrawnHtml::DocumentRenderer.new(@pdf_wrapper)
+      @html_parser = PrawnHtml::HtmlParser.new(@renderer)
+    end
+
+    def append(html:)
+      html_parser.process(html)
+    end
+  end
+end

--- a/lib/prawn_html/instance.rb
+++ b/lib/prawn_html/instance.rb
@@ -10,8 +10,9 @@ module PrawnHtml
       @html_parser = PrawnHtml::HtmlParser.new(@renderer)
     end
 
-    def append(html:)
-      html_parser.process(html)
+    def append(css: nil, html: nil)
+      html_parser.parse_styles(css) if css
+      html_parser.process(html) if html
     end
   end
 end

--- a/spec/features/instance_spec.rb
+++ b/spec/features/instance_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Instance' do
+  it 'preserves the styles in the instance' do
+    pdf = Prawn::Document.new(page_size: 'A4')
+    phtml = PrawnHtml::Instance.new(pdf)
+    phtml.append(html: '<style>h1 { color: green }</style>')
+    phtml.append(html: '<h1>Some HTML before</h1>')
+    pdf.text 'Some Prawn text'
+    phtml.append(html: '<h1>Some HTML after</h1>')
+
+    output_file = File.expand_path('../../examples/instance.pdf', __dir__)
+    pdf.render_file(output_file) unless File.exist?(output_file)
+
+    expected_pdf = File.read(output_file)
+    expect(Zlib.crc32(pdf.render)).to eq Zlib.crc32(expected_pdf)
+  end
+end

--- a/spec/features/instance_spec.rb
+++ b/spec/features/instance_spec.rb
@@ -4,10 +4,14 @@ RSpec.describe 'Instance' do
   it 'preserves the styles in the instance' do
     pdf = Prawn::Document.new(page_size: 'A4')
     phtml = PrawnHtml::Instance.new(pdf)
-    phtml.append(html: '<style>h1 { color: green }</style>')
-    phtml.append(html: '<h1>Some HTML before</h1>')
+    css = <<~CSS
+      h1 { color: green }
+      i { color: red }
+    CSS
+    phtml.append(css: css)
+    phtml.append(html: '<h1>Some <i>HTML</i> before</h1>')
     pdf.text 'Some Prawn text'
-    phtml.append(html: '<h1>Some HTML after</h1>')
+    phtml.append(html: '<h1>Some <i>HTML</i> after</h1>')
 
     output_file = File.expand_path('../../examples/instance.pdf', __dir__)
     pdf.render_file(output_file) unless File.exist?(output_file)

--- a/spec/units/prawn_html/html_parser_spec.rb
+++ b/spec/units/prawn_html/html_parser_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe PrawnHtml::HtmlParser do
     end
   end
 
+  describe '#parse_styles' do
+    subject(:parse_styles) { html_parser.parse_styles(css) }
+
+    let(:css) { 'h1 { color: red }' }
+
+    it { is_expected.to eq('h1' => 'color: red') }
+  end
+
   describe '#process' do
     subject(:process) { html_parser.process(html) }
 

--- a/spec/units/prawn_html/instance_spec.rb
+++ b/spec/units/prawn_html/instance_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe PrawnHtml::Instance do
+  describe 'initialize' do
+    subject(:instance) { described_class.new(pdf) }
+
+    let(:pdf) { instance_double(Prawn::Document) }
+
+    before do
+      allow(PrawnHtml::PdfWrapper).to receive(:new)
+      allow(PrawnHtml::DocumentRenderer).to receive(:new)
+      allow(PrawnHtml::HtmlParser).to receive(:new)
+    end
+
+    it 'initializes the required entities', :aggregate_failures do
+      instance
+      expect(PrawnHtml::PdfWrapper).to have_received(:new)
+      expect(PrawnHtml::DocumentRenderer).to have_received(:new)
+      expect(PrawnHtml::HtmlParser).to have_received(:new)
+    end
+  end
+
+  describe '#append' do
+    subject(:append) { described_class.new(pdf).append(html: html) }
+
+    let(:html) { '<h1>Some HTML</h1>' }
+    let(:html_parser) { instance_double(PrawnHtml::HtmlParser, process: nil) }
+    let(:pdf) { instance_double(Prawn::Document) }
+
+    before do
+      allow(PrawnHtml::HtmlParser).to receive(:new).and_return(html_parser)
+    end
+
+    it 'sends a process message to the html parser' do
+      append
+      expect(html_parser).to have_received(:process).with(html)
+    end
+  end
+end


### PR DESCRIPTION
Introduce a PrawnHtml::Instance to be able to preserve styles. Related to #41 

Sample usage:

```rb
  pdf = Prawn::Document.new(page_size: 'A4')
  phtml = PrawnHtml::Instance.new(pdf)
  phtml.append(html: '<style>h1 { color: green }</style>')
  phtml.append(html: '<h1>Some HTML before</h1>')
  pdf.text('Some Prawn text') # call any Prawn method external to PrawnHtml
  phtml.append(html: '<h1>Some HTML after</h1>')
```