### PR TITLE
Fix closing tag

### DIFF
--- a/lib/prawn_html/tags/table.rb
+++ b/lib/prawn_html/tags/table.rb
@@ -33,6 +33,12 @@ module PrawnHtml
           @table_data = []
         end
       end
+
+      def tag_closing(context: nil)
+        super.tap do
+          context.current_table = nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Hi @blocknotes !

I took the liberty to patch the table's closing tab, since it wouldn't render any other PDF content after a table.

Also, unrelated, I've been wondering how table styling could be introduced without bloating the API completely 🤔 In my case, I simply need borderless tables. I guess that could be inferred from the passed HTML, but all the attributes on `<table>` are deprecated: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table#attributes