### PR TITLE
Handle 'inherit' font-family value

### DIFF
--- a/lib/prawn_html/attributes.rb
+++ b/lib/prawn_html/attributes.rb
@@ -18,7 +18,7 @@ module PrawnHtml
       # text node styles
       'background' => { key: :callback, set: :callback_background },
       'color' => { key: :color, set: :convert_color },
-      'font-family' => { key: :font, set: :unquote },
+      'font-family' => { key: :font, set: :filter_font_family },
       'font-size' => { key: :size, set: :convert_size },
       'font-style' => { key: :styles, set: :append_styles, values: %i[italic] },
       'font-weight' => { key: :styles, set: :append_styles, values: %i[bold] },

--- a/lib/prawn_html/utils.rb
+++ b/lib/prawn_html/utils.rb
@@ -100,6 +100,16 @@ module PrawnHtml
       value
     end
 
+    # Filter font family
+    #
+    # @param value [String] string value
+    #
+    # @return [Symbol] unquoted font family or nil if the input value is 'inherit'
+    def filter_font_family(value, options: nil)
+      result = unquote(value, options: options)
+      result == 'inherit' ? nil : result
+    end
+
     # Normalize a style value
     #
     # @param value [String] string value
@@ -124,6 +134,6 @@ module PrawnHtml
     end
 
     module_function :callback_background, :callback_strike_through, :convert_color, :convert_float, :convert_size,
-                    :convert_symbol, :copy_value, :normalize_style, :unquote
+                    :convert_symbol, :copy_value, :filter_font_family, :normalize_style, :unquote
   end
 end

--- a/spec/units/prawn_html/attributes_spec.rb
+++ b/spec/units/prawn_html/attributes_spec.rb
@@ -50,10 +50,10 @@ RSpec.describe PrawnHtml::Attributes do
         STYLES
       end
 
-      it 'receives the expected convert messages', :aggregate_failures do
+      it 'receives the expected messages', :aggregate_failures do
         merge_text_styles!
 
-        expect(PrawnHtml::Utils).to have_received(:send).with(:unquote, "'Times-Roman'", options: nil)
+        expect(PrawnHtml::Utils).to have_received(:send).with(:filter_font_family, "'Times-Roman'", options: nil)
         expect(PrawnHtml::Utils).to have_received(:send).with(:convert_size, '16px', options: nil)
         expect(PrawnHtml::Utils).to have_received(:send).with(:convert_size, '22px', options: nil)
       end

--- a/spec/units/prawn_html/utils_spec.rb
+++ b/spec/units/prawn_html/utils_spec.rb
@@ -153,6 +153,28 @@ RSpec.describe PrawnHtml::Utils do
     end
   end
 
+  describe '.filter_font_family' do
+    subject(:filter_font_family) { described_class.filter_font_family(value) }
+
+    context 'with any string (ex. "some_string")' do
+      let(:value) { 'some_string' }
+
+      it { is_expected.to eq 'some_string' }
+    end
+
+    context 'with a string with some spaces (ex. " some_string ")' do
+      let(:value) { ' some_string ' }
+
+      it { is_expected.to eq 'some_string' }
+    end
+
+    context 'with "inherit" value' do
+      let(:value) { 'inherit' }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe '.normalize_style' do
     subject(:normalize_style) { described_class.normalize_style(value, accepted_values) }
 


### PR DESCRIPTION
In this PR:
- ignore the value if `font-family` attribute is set to `inherit`